### PR TITLE
Fix for PHP 8.1

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -25,7 +25,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $group = ($group) ?  $group : 'experius_address_lines';
         $field = ($field) ? $field : 'enabled';
         //var_dump("{$section}/{$group}/{$field}"); exit();die();
-        return $this->scopeConfig->getValue("{$section}/{$group}/{$field}", \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        return $this->scopeConfig->getValue("{$section}/{$group}/{$field}", \Magento\Store\Model\ScopeInterface::SCOPE_STORE) ?? '';
     }
 
     public function isLineEnabled($lineNumber)


### PR DESCRIPTION
Fixes error:

```
1 exception(s):
Exception #0 (Exception): Deprecated Functionality: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /data/magento2/vendor/experius/module-addresslines/Helper/Data.php on line 90
```